### PR TITLE
Fix lr decay bug. lr decay at iter 0 is wrong.

### DIFF
--- a/Deepjdot.py
+++ b/Deepjdot.py
@@ -148,7 +148,7 @@ class Deepjdot(object):
         
         for i in range(n_iter):
             
-            if self.lr_decay and i%5000 ==0:
+            if self.lr_decay and i > 0 and i%5000 ==0:
                 # p = float(i) / n_iter
                 # lr = self.int_lr / (1. + 10 * p)**0.9
                 lr = dnn.K.get_value(self.model.optimizer.lr)

--- a/deepjdot_svhn_mnist.py
+++ b/deepjdot_svhn_mnist.py
@@ -335,7 +335,7 @@ class jdot_align(object):
         self.model.compile(optimizer= optim, loss =[self.classifier_cat_loss, self.align_loss])
         dnn.K.set_value(self.model.optimizer.lr, self.int_lr)        
         for i in range(n_iter):
-            if self.lr_decay and i%10000 ==0:
+            if self.lr_decay and i > 0 and i%10000 ==0:
                 # p = float(i) / n_iter
                 # lr = self.int_lr / (1. + 10 * p)**0.9
                 lr = dnn.K.get_value(self.model.optimizer.lr)


### PR DESCRIPTION
This means that the learning rate that was used in the past was all wrong.
This might need a further experiment to see if the initial learning rate has to be decreased in order to obtain the same accuracy on demo and SVHN.
